### PR TITLE
FEM-2829 Update Player Events documentation

### DIFF
--- a/documentation/player-portal/ios/player-events-ios.md
+++ b/documentation/player-portal/ios/player-events-ios.md
@@ -38,7 +38,7 @@ player.addObserver(self, events: [PlayerEvent.playing, PlayerEvent.durationChang
 
 ### Listening to events from plugin code
 
-Plugins can't call `addObserver` on the player, instead, an identical function exists on the `MessageBus` object that is passed to the plugin.
+Plugins can't call `addObserver` on the player; instead, an identical function exists on the `MessageBus` object that is passed to the plugin.
 
 ## Core Player Events
 

--- a/documentation/player-portal/ios/player-events-ios.md
+++ b/documentation/player-portal/ios/player-events-ios.md
@@ -14,65 +14,92 @@ The code below will add an observer to a list of various events.
 
 {% highlight swift %}
 player.addObserver(self, events: [PlayerEvent.playing, PlayerEvent.durationChanged, PlayerEvent.stateChanged]) { [weak self] event in
-     if type(of: event) == PlayerEvent.playing {
+    guard let self = self else { return }
+    switch event {
+    case is PlayerEvent.Playing:
         // handle playing event
-     } else if type(of: event) == PlayerEvent.durationChanged {
-        let duration = event.duration
-     } else if type(of: event) == PlayerEvent.stateChanged {
+        break
+    case is PlayerEvent.DurationChanged:
+        if let playerEvent = event as? PlayerEvent, let duration = playerEvent.duration as? TimeInterval {
+            let duration = duration
+        }
+    case is PlayerEvent.PlayheadUpdate:
+        if let playerEvent = event as? PlayerEvent, let currentTime = playerEvent.currentTime {
+            self.playheadSlider.value = Float(self.player.currentTime / self.player.duration)
+        }
+    case is PlayerEvent.StateChanged:
         let newState = event.newState
         let oldState = event.oldState
-     }
+    default:
+        break
+    }
 }
 {% endhighlight %}
 
 ### Listening to events from plugin code
 
-Plugins can't call `addObserver` on the player; instead, an identical function exists on the `MessageBus` object that is passed to the plugin.
+Plugins can't call `addObserver` on the player, instead, an identical function exists on the `MessageBus` object that is passed to the plugin.
 
 ## Core Player Events
 
 The Player events are defined in the PlayerEvent class.
 
 ### Normal Flow
-- **sourceSelected:** Sent when a playback source is selected
-- **loadedMetadata:** The media's metadata has finished loading; all attributes now contain as much useful information as they're going to.
-- **durationChanged:** The metadata has loaded or changed, indicating a change in duration of the media. This is sent, for example, when the media has loaded enough that the duration is known.
-- **tracksAvailable:** Sent when track info is available.
-- **playbackInfo:** Sent event that notify about changes in the playback parameters. When bitrate of the video or audio track changes or new media loaded. Holds the PlaybackInfo.java object with relevant data.
-- **canPlay:** Sent when enough data is available that the media can be played, at least for a couple of frames. This corresponds to the HAVE_ENOUGH_DATA readyState.
-- **play:** Sent when playback of the media starts after having been paused; that is, when playback is resumed after a prior pause event.
-- **playing:** Sent when the media begins to play (either for the first time, after having been paused, or after ending and then restarting).
-- **ended:** Sent when playback completes.
+- **SourceSelected:** Sent when a playback source is selected.
+- **LoadedMetadata:** The media's metadata has finished loading, all attributes now contain as much useful information as they're going to.
+- **DurationChanged:** The metadata has loaded or changed, indicating a change in duration of the media. This is sent, for example, when the media has loaded enough that the duration is known.
+- **TracksAvailable:** Sent when track info is available.
+- **PlaybackInfo:** Sent to notify about changes in the playback parameters. When bitrate of the video or audio track changes or new media is loaded. Holds the PlaybackInfo.java object with relevant data.
+- **CanPlay:** Sent when enough data is available that the media can be played, at least for a couple of frames. This corresponds to the HAVE_ENOUGH_DATA readyState.
+- **Play:** Sent when playback of the media starts after having been paused; that is, when playback is resumed after a prior pause event.
+- **Playing:** Sent when the media begins to play (either for the first time, after having been paused, or after ending and then restarting).
+- **Ended:** Sent when playback completes.
 
-### Additional User actions
-- **pause:** Sent when playback is paused.
-- **seeked:** Sent when a seek operation completes.
-- **seeking:** Sent when a seek operation begins.
-- **stopped:** sent when stop player API is called
+### Additional User Actions
+- **Pause:** Sent when playback is paused.
+- **Seeked:** Sent when a seek operation completes.
+- **Seeking:** Sent when a seek operation begins.
+- **Stopped:** Sent when stop player API is called
+- **Replay:** Sent when a replay operation is performed.
 
-### Track change
-- **videoTrackChanged:** A video track was selected
-- **audioTrackChanged:** An audio track was selected
-- **textTrackChanged:** A text track was selected
+### Playhead
+- **PlayheadUpdate:** Sent when the playhead (current time) has moved.
+- **LoadedTimeRanges:** Sent when loaded time ranges was changed, loaded time ranges represent the buffered content. Could be used to show amount buffered on the playhead UI.
+
+### Track Change
+- **VideoTrackChanged:** A video track was selected
+- **AudioTrackChanged:** An audio track was selected
+- **TextTrackChanged:** A text track was selected
 
 ### Metadata (ID3 tags and related)
-- **timedMetadata:** Sent when there is metadata available for this entry.
-
-### Errors
-- **error:** Sent when an error occurs. The element's error attribute contains more information. See Error handling for details.
+- **TimedMetadata:** Sent when there is metadata available for this entry.
 
 ### State Change
+- **StateChanged:** Sent when player state is changed.
+
 The Player can be in one of 4 playback states:
 
-  `idle`, `buffering`, `ready`, `ended`
+  `idle`, `buffering`, `ready`, `ended`, `error`
   
-The `stateChanged` event is fired when the player transitions between states.
+### Stalled
+- **PlaybackStalled:** Sent when the player has stalled. Buffering with no available data to play.
+
+### Errors
+- **Error:** Sent when an error occurs. The element's error attribute contains more information. See Error handling for details.
+- **ErrorLog:** Sent when an error log event received from player (non fatal errors).
+
 
 ## Ad Events
 
 Defined in AdEvent class.
 
+- streamLoaded // Only in DAI
+- streamStarted // Only in DAI
 - adBreakReady
+- adBreakStarted // Only in DAI
+- adBreakEnded // Only in DAI
+- adPeriodStarted // Only in DAI
+- adPeriodEnded // Only in DAI
 - allAdsCompleted
 - adComplete
 - adClicked
@@ -89,12 +116,17 @@ Defined in AdEvent class.
 - adDidProgressToTime
 - adDidRequestContentPause
 - adDidRequestContentResume
+- adWebOpenerWillOpenExternalBrowser
+- adWebOpenerWillOpenInAppBrowser
+- adWebOpenerDidOpenInAppBrowser
+- adWebOpenerWillCloseInAppBrowser
+- adWebOpenerDidCloseInAppBrowser
 - adCuePointsUpdate
 - adStartedBuffering
 - adPlaybackReady
 - requestTimedOut
 - adsRequested
+- error
 
-## Code Samples
-- [Events Registration](https://github.com/kaltura/playkit-ios-samples/tree/master/EventsRegistration)
-- [App Analytics](https://github.com/kaltura/playkit-ios-samples/tree/master/AppAnalyticsSample)
+## Code Sample
+- [Events Registration](https://github.com/kaltura/playkit-ios-samples/tree/develop/EventsRegistration)


### PR DESCRIPTION
Updated example.
Added missing events.
Updated the link to the Events Registration sample.


